### PR TITLE
Update good-old-form.js for Express 4.x

### DIFF
--- a/expressworks/good-old-form.js
+++ b/expressworks/good-old-form.js
@@ -2,7 +2,7 @@ var express = require('express');
 
 var app = express();
 
-app.use(express.urlencoded());
+app.use(require('body-parser').urlencoded());
 app.post('/form', (req, res) => {
   res.end(req.body.str.split('').reverse().join(''));
 });


### PR DESCRIPTION
Solves the following error when using Express 4.x:
Error: Most middleware (like urlencoded) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.

Source: https://github.com/nodeschool/discussions/issues/274#issuecomment-41640407